### PR TITLE
R code execution error on `Url`

### DIFF
--- a/R/urlr.R
+++ b/R/urlr.R
@@ -8,7 +8,7 @@
 
 urlr <- function(){
   a <- rstudioapi::getSourceEditorContext()
-  content <- paste0("[", content, "](", content, ")")
+  content <- paste0("[](", a$selection[[1]]$text, ")")
   rstudioapi::insertText(location = a$selection[[1]]$range, text = content)
 }
 


### PR DESCRIPTION
I got an R code execution error after trying to format a `Url`. 
```{r}
Error in paste0("[", content, "](", content, ")") : 
  object 'content' not found
```
This should fix it.