### PR TITLE
Adds addin to add cran link

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Authors@R: c(person("Colin", "Fay", email = "contact@colinfay.me", role = c("aut
              person("Jonathan", "Carroll", email = "rpkg@jcarroll.com.au", role = c("ctb"), comment = c(ORCID = "0000-0002-1404-5264")),
              person("Andrzej", "Oleś", email = "andrzej.oles@gmail.com", role = c("ctb"), comment = c(ORCID = "0000-0003-0285-2787")),
              person("Daniel", "Possenriede", email = "possenriede@gmail.com", role = c("ctb"), comment = c(ORCID = "0000-0002-6738-9845")),
+             person("Roel M.", "Hogervorst", email = "hogervorst.rm@gmail.com", role = c("ctb"),comment = c(ORCID = "0000-0001-7509-0328")),
              person(given = "ThinkR", role = "cph"))
 Description: An 'RStudio' addin providing shortcuts for writing in 'Markdown'. This package provides a series of 
              functions that allow the user to be more efficient when using 'Markdown'. For example, you can select 

--- a/R/packager.R
+++ b/R/packager.R
@@ -1,0 +1,25 @@
+#' @title packager
+#'
+#' @description Turn bare package name into canonical cran link and make curly braces around the package name.
+#'
+#'
+#' @return a markdown link to CRAN
+#' @export
+#' @importFrom rstudioapi getSourceEditorContext modifyRange
+#' 
+#' @examples 
+#' \dontrun{
+#' remedy_example(
+#'     c( "remedy"),
+#'     packager
+#'     )
+#'  }
+packager <- function() {
+  
+  adc <- rstudioapi::getSourceEditorContext()
+  txt <- adc$selection[[1]]$text
+  
+  content <- sprintf('[{%s}](https://CRAN.R-project.org/package=%s)',txt, txt)
+  
+  rstudioapi::modifyRange(location = adc$selection[[1]]$range, text = content, id = adc$id)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -198,6 +198,10 @@ Turn an url into a youtube embed:
 Insert a xaringan pull-left and pull-right template. 
 
 ![](reference/figures/xaringan.gif)
+### CRAN url 
+
+Turn package names into canonical CRAN links. From remedy to [{remedy}](https://CRAN.R-project.org/package=remedy).
+
 
 ## Recommended shortcuts (macOS)
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Summary](https://img.shields.io/badge/covrpage-Last_Build_2018_12_21-brightgreen
 
 <img src="https://raw.githubusercontent.com/ThinkR-open/remedy/master/reference/figures/thinkr-hex-remedy.png" width=250px>
 
-remedy
-======
+# remedy
 
 `{remedy}` provides addins to facilitate writing in markdown with
 RStudio.
@@ -26,21 +25,21 @@ of suggested shortcuts is provided towards the end of this README.
 > Note that most of the addins/shortcuts below will also work without
 > selecting any text.
 
-Install
--------
+## Install
 
-    remotes::install_github("ThinkR-open/remedy")
+``` r
+remotes::install_github("ThinkR-open/remedy")
+```
 
 Once you’ve installed the package, you don’t need to load it with
 `library()`, the addins are installed on your machine as part of the
 package install process.
 
-Using `{remedy}`
-----------------
+## Using `{remedy}`
 
 Write quicker in markdown with `{remedy}`!  
 Read the full manual in the associated {pkgdown} website:
-<a href="https://thinkr-open.github.io/remedy/" class="uri">https://thinkr-open.github.io/remedy/</a>
+<https://thinkr-open.github.io/remedy/>
 
 Here’s a list of all available helpers:
 
@@ -49,8 +48,10 @@ Here’s a list of all available helpers:
 You can also have an overview of how the functions behave with the
 `remedy_example()` function:
 
-    library(remedy)
-    remedy_example( c("Never gonna", "give you up", "let you down"), listr )
+``` r
+library(remedy)
+remedy_example( c("Never gonna", "give you up", "let you down"), listr )
+```
 
 ### Align
 
@@ -186,26 +187,30 @@ Turn an url into a youtube embed:
 
 Insert a xaringan pull-left and pull-right template.
 
-![](reference/figures/xaringan.gif)
+![](reference/figures/xaringan.gif) \#\#\# CRAN url
 
-Recommended shortcuts (macOS)
------------------------------
+Turn package names into canonical CRAN links. From remedy to
+[{remedy}](https://CRAN.R-project.org/package=remedy).
+
+## Recommended shortcuts (macOS)
 
 Here’s a list of recommended shortcuts:
 
-    remedy::remedy_opts$get('hotkeys')
-    #>           backtick               bold              chunk         chunksplit 
-    #>       "Ctrl+Cmd+`"       "Ctrl+Cmd+B"   "Ctrl+Alt+Cmd+C" "Ctrl+Shift+Alt+C" 
-    #>          chunkname           footnote                 h1                 h2 
-    #> "Ctrl+Shift+Alt+N" "Ctrl+Cmd+Shift+6"       "Ctrl+Cmd+1"       "Ctrl+Cmd+2" 
-    #>                 h3                 h4                 h5                 h6 
-    #>       "Ctrl+Cmd+3"       "Ctrl+Cmd+4"       "Ctrl+Cmd+5"       "Ctrl+Cmd+6" 
-    #>        htmlcomment              image            italics              latex 
-    #>       "Ctrl+Alt+C"       "Ctrl+Cmd+P"       "Ctrl+Cmd+I"       "Ctrl+Cmd+L" 
-    #>               list              right             strike              table 
-    #> "Ctrl+Shift+Cmd+="    "Alt+Cmd+Right"       "Ctrl+Cmd+S"       "Ctrl+Cmd+T" 
-    #>                url           xaringan            youtube 
-    #>       "Ctrl+Cmd+U"       "Ctrl+Cmd+X"       "Ctrl+Cmd+Y"
+``` r
+remedy::remedy_opts$get('hotkeys')
+#>           backtick               bold              chunk         chunksplit 
+#>       "Ctrl+Cmd+`"       "Ctrl+Cmd+B"   "Ctrl+Alt+Cmd+C" "Ctrl+Shift+Alt+C" 
+#>          chunkname           footnote                 h1                 h2 
+#> "Ctrl+Shift+Alt+N" "Ctrl+Cmd+Shift+6"       "Ctrl+Cmd+1"       "Ctrl+Cmd+2" 
+#>                 h3                 h4                 h5                 h6 
+#>       "Ctrl+Cmd+3"       "Ctrl+Cmd+4"       "Ctrl+Cmd+5"       "Ctrl+Cmd+6" 
+#>        htmlcomment              image            italics              latex 
+#>       "Ctrl+Alt+C"       "Ctrl+Cmd+P"       "Ctrl+Cmd+I"       "Ctrl+Cmd+L" 
+#>               list              right             strike              table 
+#> "Ctrl+Shift+Cmd+="    "Alt+Cmd+Right"       "Ctrl+Cmd+S"       "Ctrl+Cmd+T" 
+#>                url           xaringan            youtube 
+#>       "Ctrl+Cmd+U"       "Ctrl+Cmd+X"       "Ctrl+Cmd+Y"
+```
 
 ### Managing Shortcuts
 
@@ -216,17 +221,17 @@ If you want to edit the default settings you can view the defaults
 `remedy_opts$get('hotkeys')` and change them through
 `remedy_opts$set(hotkeys=<NEW_SETTINGS>)`.
 
-    hotkeys <- remedy::remedy_opts$get("hotkeys")
-    rsam::set_shortcut(sprintf('remedy::%sr',names(hotkeys)), hotkeys)
+``` r
+hotkeys <- remedy::remedy_opts$get("hotkeys")
+rsam::set_shortcut(sprintf('remedy::%sr',names(hotkeys)), hotkeys)
+```
 
-Feedback and enhancement
-------------------------
+## Feedback and enhancement
 
 You’ve found a bug, or have an enhancement idea? Feel free to open an
 issue : <https://github.com/ThinkR-open/remedy/issues>.
 
-Code of conduct
----------------
+## Code of conduct
 
 Please note that the ‘remedy’ project is released with a [Contributor
 Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project,

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -147,3 +147,8 @@ Name: Youtube
 Description: Convert selected text into a markdown youtube frame
 Binding: youtuber
 Interactive: false
+
+Name: CRAN Link
+Description: Turn package name into CRAN link and add curly braces
+Binding: packager
+Interactive: false

--- a/tests/testthat/test-packager.R
+++ b/tests/testthat/test-packager.R
@@ -1,0 +1,9 @@
+testthat::context("make cran link")
+
+sec <- scratch_file()
+testthat::describe("packager creates cran link", {
+  set_text("dplyr", sec = sec)
+  packager()
+  rstudioapi::documentSave(sec$id)
+  testthat::expect_equal(readLines(sec$path, warn = FALSE), c("[{dplyr}](https://CRAN.R-project.org/package=dplyr)"))
+})


### PR DESCRIPTION

If applied, this commit will create an extra remedy function: package linker. 
This allows you to select a piece of markdown and turn it into a link to the CRAN page.

example: 

* `the package remedy is used for...`
* select dplyr and use the `packager()` function
* `the package [{remedy}](https://CRAN.R-project.org/package=remedy) is used for..`


I also added a test, but I'm not sure I'm using the helperfunctions correctly. 

I didn't add a shortcut, because frankly I wouldn't know which one to use.
